### PR TITLE
Updated haml.js to the last version

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ RubyHamlJs::Template.custom_escape = "App.escape_html"
 This will use the given function and will not generate custom escape code inside each template.
 But you need to make sure that the function is defined before using the templates in JavaScript.
 
+## Custom haml.js
+
+If you need a custom version of haml.js library you may specify it using the haml_path
+
+```ruby
+RubyHamlJs::Template.haml_path = "path/to/haml.js"
+```
+
 # Development
 
 - Source hosted at [GitHub](https://github.com/dnagir/ruby-haml-js)

--- a/lib/ruby-haml-js/template.rb
+++ b/lib/ruby-haml-js/template.rb
@@ -50,10 +50,12 @@ module RubyHamlJs
 
     class << self
       attr_accessor :custom_escape
+      attr_accessor :haml_path
 
       def haml_source
         # Haml source is an asset
-        @haml_source ||= IO.read File.expand_path('../../../vendor/assets/javascripts/haml.js', __FILE__) 
+        @haml_path = File.expand_path('../../../vendor/assets/javascripts/haml.js', __FILE__) if @haml_path.nil?
+        @haml_source ||= IO.read @haml_path
       end
 
     end

--- a/vendor/assets/javascripts/haml.js
+++ b/vendor/assets/javascripts/haml.js
@@ -311,8 +311,50 @@ var Haml;
       regexp: /^(\s*):if\s+(.*)\s*$/i,
       process: function () {
         var condition = this.matches[2];
+        this.pushIfCondition([condition]);
         return '(function () { ' +
           'if (' + condition + ') { ' +
+          'return (\n' + (this.render_contents() || '') + '\n);' +
+          '} else { return ""; } }).call(this)';
+      }
+    },
+    
+    // else if statements
+    {
+      name: "else if",
+      regexp: /^(\s*):else if\s+(.*)\s*$/i,
+      process: function () {
+        var condition = this.matches[2],
+          conditionsArray = this.getIfConditions()[this.getIfConditions().length - 1],
+          ifArray = [],
+          ifStatement;
+        for (var i=0, l=conditionsArray.length; i<l; i++) {
+          ifArray.push('! (' + conditionsArray[i]+')');
+        }
+        conditionsArray.push(condition);
+        ifArray.push(condition);
+        ifStatement = 'if (' + ifArray.join(' && ') + ') { ';
+        return '(function () { ' +
+          ifStatement +
+          'return (\n' + (this.render_contents() || '') + '\n);' +
+          '} else { return ""; } }).call(this)';
+      }
+    },
+    
+    // else statements
+    {
+      name: "else",
+      regexp: /^(\s*):else\s*$/i,
+      process: function () {
+        var conditionsArray = this.popIfCondition(),
+          ifArray = [],
+          ifStatement;
+        for (var i=0, l=conditionsArray.length; i<l; i++) {
+          ifArray.push('! (' + conditionsArray[i]+')');
+        }
+        ifStatement = 'if (' + ifArray.join(' && ') + ') { ';
+        return '(function () { ' +
+          ifStatement +
           'return (\n' + (this.render_contents() || '') + '\n);' +
           '} else { return ""; } }).call(this)';
       }
@@ -443,7 +485,8 @@ var Haml;
 
   function compile(lines) {
     var block = false,
-        output = [];
+        output = [],
+        ifConditions = [];
 
     // If lines is a string, turn it into an array
     if (typeof lines === 'string') {
@@ -475,6 +518,15 @@ var Haml;
               matches: match,
               check_indent: new RegExp("^(?:\\s*|" + match[1] + "  (.*))$"),
               process: matcher.process,
+              getIfConditions: function() {
+                return ifConditions;
+              },
+              pushIfCondition: function(condition) {
+                ifConditions.push(condition);
+              },
+              popIfCondition: function() {
+                return ifConditions.pop();
+              },
               render_contents: function () {
                 return compile(this.contents);
               }
@@ -483,7 +535,7 @@ var Haml;
           }
         }
       });
-
+      
       // Match plain text
       if (!found) {
         output.push(function () {
@@ -649,3 +701,4 @@ var Haml;
 if (typeof module !== 'undefined') {
   module.exports = Haml;
 }
+


### PR DESCRIPTION
Looks like current version does not support

```
:else if
:else
```

Added configurable haml_path:

```
# config/application.rb
RubyHamlJs::Template.haml_path = "#{config.root}/vendor/assets/javascripts/haml.js"
```
