### PR TITLE
Rails 4 compatibility

### DIFF
--- a/lib/ruby-haml-js/engine.rb
+++ b/lib/ruby-haml-js/engine.rb
@@ -1,13 +1,10 @@
 module RubyHamlJs
   class Engine < Rails::Engine
-    initializer "ruby-hamljs.configure_rails_initialization", :before => 'sprockets.environment', :group => :all do |app|
-      next unless app.config.assets.enabled
+    initializer "ruby-hamljs.configure_rails_initialization", :after => 'sprockets.environment', :group => :all do |app|
+      next unless app.assets
 
-      require 'sprockets'
-      require 'sprockets/engines'
       require 'ruby-haml-js/template'
-      #app.config.assets.register_engine '.hamljs', ::RubyHamlJs::Template
-      Sprockets.register_engine '.hamljs', ::RubyHamlJs::Template
+      app.assets.register_engine '.hamljs', ::RubyHamlJs::Template
     end
   end
 end


### PR DESCRIPTION
I'm not sure why but Sprockets.register_engine does not work in rails 4.

Using app.assets.register_engine to add hamljs engine, handlebars uses the same way, see https://github.com/leshill/handlebars_assets/blob/master/lib/handlebars_assets/engine.rb
