### PR TITLE
Fix running JavaScript (-) to specification.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source "http://rubygems.org"
 gemspec
 
 group :development, :test do
+  gem 'rails', '~> 3.2.14'
   gem 'pry'
 end

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -43,6 +43,170 @@ describe RubyHamlJs::Template do
     end
   end
 
+  describe 'rawjs.if.simple' do
+    let(:choice) { true }
+    subject do
+      func = render <<eot, 'myTemplate.js.hamljs'
+- if (choice)
+  %p it is so
+eot
+      ExecJS.compile("var f = #{func};").eval "f({choice: #{choice}})"
+    end
+
+    it { should include '<p>it is so</p>' }
+
+    context "changing opinion" do
+      let(:choice) { false }
+      it { should_not include '<p>it is so</p>' }
+    end
+  end
+
+  describe 'rawjs.if.begin' do
+    let(:choice) { true }
+    subject do
+      func = render <<eot, 'myTemplate.js.hamljs'
+- if (choice) {
+  %p it is so
+eot
+      ExecJS.compile("var f = #{func};").eval "f({choice: #{choice}})"
+    end
+
+    it { should include '<p>it is so</p>' }
+
+    context "changing opinion" do
+      let(:choice) { false }
+      it { should_not include '<p>it is so</p>' }
+    end
+  end
+
+  describe 'rawjs.for.simple' do
+    let(:list) { [1,2,3] }
+    subject do
+      func = render <<eot, 'myTemplate.js.hamljs'
+- for (i=0; i < list.length; i++)
+  %p= list[i]
+eot
+      ExecJS.compile("var f = #{func};").eval "f({list: #{list}})"
+    end
+
+    it { should include '<p>1</p>' }
+    it { should include '<p>2</p>' }
+    it { should include '<p>3</p>' }
+
+  end
+
+  describe 'rawjs.for.begin' do
+    let(:list) { [1,2,3] }
+    subject do
+      func = render <<eot, 'myTemplate.js.hamljs'
+- for (i=0; i < list.length; i++) {
+  %p= list[i]
+eot
+      ExecJS.compile("var f = #{func};").eval "f({list: #{list}})"
+    end
+
+    it { should include '<p>1</p>' }
+    it { should include '<p>2</p>' }
+    it { should include '<p>3</p>' }
+
+  end
+
+  describe 'rawjs.for.in' do
+    let(:list) { [1,2,3] }
+    subject do
+      func = render <<eot, 'myTemplate.js.hamljs'
+- for (i in list)
+  %p= list[i]
+eot
+      ExecJS.compile("var f = #{func};").eval "f({list: #{list}})"
+    end
+
+    it { should include '<p>1</p>' }
+    it { should include '<p>2</p>' }
+    it { should include '<p>3</p>' }
+
+  end
+
+  describe 'rawjs.assign' do
+    let(:list) { [1,2,3] }
+    subject do
+      func = render <<eot, 'myTemplate.js.hamljs'
+- for (i=0; i < list.length; i++) {
+  - pval = list[i];
+  %p= pval
+eot
+      ExecJS.compile("var f = #{func};").eval "f({list: #{list}})"
+    end
+
+    it { should include '<p>1</p>' }
+    it { should include '<p>2</p>' }
+    it { should include '<p>3</p>' }
+
+  end
+
+  describe 'rawjs.for.complex' do
+    let(:list) { [1,2,3] }
+    subject do
+      func = render <<eot, 'myTemplate.js.hamljs'
+- for (i = 0; i < list.length; i++)
+  %i= i
+  - if (list[i] == 1)
+    %p one
+  - if (list[i] == 2)
+    %p two
+  - if (list[i] == 3)
+    %p three
+  %p= list[i]
+eot
+      ExecJS.compile("var f = #{func};").eval "f({list: #{list}})"
+    end
+
+    it { should include '<i>0</i>' }
+    it { should include '<i>1</i>' }
+    it { should include '<i>2</i>' }
+    it { should include '<p>1</p>' }
+    it { should include '<p>2</p>' }
+    it { should include '<p>3</p>' }
+    it { should include '<p>one</p>' }
+    it { should include '<p>two</p>' }
+    it { should include '<p>three</p>' }
+
+  end
+
+  describe 'rawjs.while' do
+    let(:list) { [1,2,3] }
+    subject do
+      func = render <<eot, 'myTemplate.js.hamljs'
+- i = 0;
+- while (i < list.length) {
+  %p= list[i]
+  - i++;
+eot
+      ExecJS.compile("var f = #{func};").eval "f({list: #{list}})"
+    end
+
+    it { should include '<p>1</p>' }
+    it { should include '<p>2</p>' }
+    it { should include '<p>3</p>' }
+
+  end
+
+  describe 'rawjs.async' do
+    let(:list) { [1,2,3] }
+    subject do
+      func = render <<eot, 'myTemplate.js.hamljs'
+- list.forEach(function (i) {
+  %p= i
+eot
+      ExecJS.compile("var f = #{func};").eval "f({list: #{list}})"
+    end
+
+    it { should include '<p>1</p>' }
+    it { should include '<p>2</p>' }
+    it { should include '<p>3</p>' }
+
+  end
+
   describe 'serving' do
     subject { assets }
     it { should serve 'sample.js' }

--- a/vendor/assets/javascripts/haml.js
+++ b/vendor/assets/javascripts/haml.js
@@ -1,5 +1,5 @@
 var Haml;
- 
+
 (function () {
 
   var matchers, self_close_tags, embedder, forceXML, escaperName, escapeHtmlByDefault;
@@ -159,7 +159,7 @@ var Haml;
         //unsafe!!!
         items.push(match[2] || match[3]);
       }
-      
+
       pos += next;
     }
     return items.filter(function (part) { return part && part.length > 0}).join(" +\n");
@@ -194,7 +194,7 @@ var Haml;
             var leader0 = attribs._content.charAt(0),
                 leader1 = attribs._content.charAt(1),
                 leaderLength = 0;
-                
+
             if(leader0 == "<"){
               leaderLength++;
               whitespace.inside = true;
@@ -251,7 +251,7 @@ var Haml;
         if (content === '""') {
           content = '';
         }
-        
+
         if(whitespace.inside){
           if(content.length==0){
             content='"  "'
@@ -260,7 +260,7 @@ var Haml;
               content = '" '+JSON.parse(content)+' "';
             }catch(e){
               content = '" "+\n'+content+'+\n" "';
-            }            
+            }
           }
         }
 
@@ -271,7 +271,7 @@ var Haml;
         } else {
           output = '"<' + tag + attribs + ' />"';
         }
-        
+
         if(whitespace.around){
           //output now contains '"<b>hello</b>"'
           //we need to crack it open to insert whitespace.
@@ -318,7 +318,7 @@ var Haml;
           '} else { return ""; } }).call(this)';
       }
     },
-    
+
     // else if statements
     {
       name: "else if",
@@ -340,7 +340,7 @@ var Haml;
           '} else { return ""; } }).call(this)';
       }
     },
-    
+
     // else statements
     {
       name: "else",
@@ -359,7 +359,7 @@ var Haml;
           '} else { return ""; } }).call(this)';
       }
     },
-    
+
     // silent-comments
     {
       name: "silent-comments",
@@ -368,18 +368,18 @@ var Haml;
         return '""';
       }
     },
-    
+
     //html-comments
     {
       name: "silent-comments",
       regexp: /^(\s*)\/\s*(.*)\s*$/i,
       process: function () {
         this.contents.unshift(this.matches[2]);
-        
+
         return '"<!--'+this.contents.join('\\n')+'-->"';
       }
     },
-    
+
     // raw js
     {
       name: "rawjs",
@@ -399,7 +399,7 @@ var Haml;
         return '"<pre>"+\n' + JSON.stringify(this.contents.join("\n"))+'+\n"</pre>"';
       }
     },
-    
+
     // declarations
     {
       name: "doctype",
@@ -535,7 +535,7 @@ var Haml;
           }
         }
       });
-      
+
       // Match plain text
       if (!found) {
         output.push(function () {
@@ -552,7 +552,7 @@ var Haml;
               return escaperName+'(' + line + ')';
             }
           }
-          
+
           function unescapedLine(){
             try {
               return parse_interpol(JSON.parse(line));
@@ -560,19 +560,19 @@ var Haml;
               return line;
             }
           }
-          
+
           // always escaped
           if((line.substr(0, 2) === "&=")) {
             line = line.substr(2, line.length).trim();
             return escapedLine();
           }
-          
+
           //never escaped
           if((line.substr(0, 2) === "!=")) {
             line = line.substr(2, line.length).trim();
             return unescapedLine();
           }
-          
+
           // sometimes escaped
           if ( (line[0] === '=')) {
             line = line.substr(1, line.length).trim();
@@ -592,7 +592,7 @@ var Haml;
     if (block) {
       output.push(block.process());
     }
-    
+
     var txt = output.filter(function (part) { return part && part.length > 0}).join(" +\n");
     if(txt.length == 0){
       txt = '""';
@@ -659,7 +659,7 @@ var Haml;
       forceXML = config;
       config = {};
     }
-    
+
     var escaper;
     if(config.customEscape){
       escaper = "";
@@ -668,11 +668,11 @@ var Haml;
       escaper = html_escape.toString() + "\n";
       escaperName = "html_escape";
     }
-    
+
     escapeHtmlByDefault = (config.escapeHtmlByDefault || config.escapeHTML || config.escape_html);
-    
+
     var js = optimize(compile(haml));
-    
+
     var str = "with(locals || {}) {\n" +
     "  try {\n" +
     "   var _$output=" + js + ";\n return _$output;" +

--- a/vendor/assets/javascripts/haml.js
+++ b/vendor/assets/javascripts/haml.js
@@ -385,8 +385,17 @@ var Haml;
       name: "rawjs",
       regexp: /^(\s*)-\s*(.*)\s*$/i,
       process: function () {
-        this.contents.unshift(this.matches[2]);
-        return '"";' + this.contents.join("\n")+"; _$output = _$output ";
+        contents = ["_$output = _$output + "+ compile(this.contents.join("\n"))];
+        if (this.matches[2].match(/{$/))
+          contents.push(';}');
+        else if(this.matches[2].match(/^if|^for|^while/)) {
+          contents.unshift('{');
+          contents.push(';}');
+        }
+        if (this.matches[2].match(/function/))
+          contents.push(')');
+        contents.unshift(this.matches[2]);
+        return '"";\n' + contents.join("\n")+"; _$output = _$output ";
       }
     },
 


### PR DESCRIPTION
I saw the undocumented custom filter hacks referred to by #9 but those `:if` and `:loop`  constructs are one of the gripes I have with jade, these are not required in a templating engine, IMO. We have sufficient ability to handle conditions and loops in the underlying language so it is unnecessary for the template engine to duplicate the effort.

Whether to keep the out of spec features or not is not what this patch is aiming for, instead it is an attempt to make the JavaScript lines run as `-` working as is expected.

What has been added:
- running JavaScript blocks are completely processed to allow for other type lines to be included in blocks including nesting of JavaScript blocks
- as per the haml specification to use indentation for blocks you are not required to end
  - if statements
  - for loops
  - while loops
  - async function blocks
- includes several specs to test the commonly used combinations including
  - if statements with and without begin `{`
  - for loops with or without begin `{`
  - for in loop
  - while loop
  - variable assignment
  - async function blocks

See spec for example.

Although this is already very useful and serves the majority of use cases there are some things that still need attention. We currently only consider the immediate block of the parent but in certain conditions we will have to take the first outdent into consideration. This means that the following will not work yet.
- `else` and `else if` statements will not work as we prepare the _$output variable for subsequent lines after the if statement was already closed.  
- It is not possible to implicitly close a block (this is not to spec but may be required for async function blocks)
- only async functions as the last parameter of a method is currently supported due to the limitation mentioned previously.

Because we are not yet considering the first outdented line something like `setTimeout` is not possible yet.
ex.

``` haml
- setTimeout(function () {
 %p This html supplied asynchronously
- }, 1000);

```

But even with these remaining limitations I consider this patch a move in the right direction as the rawjs implementation is not of any use currently. 
